### PR TITLE
Unescape URI so `:` character is correctly propagated.

### DIFF
--- a/lib/buildkit/client.rb
+++ b/lib/buildkit/client.rb
@@ -160,7 +160,7 @@ module Buildkit
     end
 
     def build_path(uri)
-      "#{uri.path}?#{uri.query}"
+      CGI.unescape("#{uri.path}?#{uri.query}")
     end
 
     def sawyer_agent


### PR DESCRIPTION
When passing dates with auto paginated commands, the request would fail. This is because the next page was not escaped before issuing the next request.

Causing the following error.

```
field: created_from
  code: Created from is not a valid date: "2021-04-27T09%3A30%3A15-07%3A00"
  value: 2021-04-27T09%3A30%3A15-07%3A00
 ```

To solve this, we can simply unescape the created URI.